### PR TITLE
Remove external references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,10 +38,8 @@ Suggests:
     tibble,
     whirl (>= 0.1.8.9000)
 VignetteBuilder: 
-    knitr, rmarkdown
-Remotes: 
-    github::NovoNordisk-OpenSource/connector,
-    github::NovoNordisk-Opensource/whirl
+    knitr, 
+    rmarkdown
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,11 +40,8 @@ Suggests:
 VignetteBuilder: 
     knitr, rmarkdown
 Remotes: 
-    github::databrickslabs/brickster,
     github::NovoNordisk-OpenSource/connector,
-    github::r-dbi/odbc@v1.4.0,
-    novonordisk-opensource/whirl,
-    r-lib/mockery
+    github::NovoNordisk-Opensource/whirl
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: connector.databricks
+Version: 0.0.4
 Title: Expansion of the connector package for enabling connections to
     databricks
-Version: 0.0.4
 Authors@R: c(
     person("Steffen Falgreen", "Larsen", , "sffl@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = "aut"),
@@ -38,8 +38,10 @@ Suggests:
     tibble,
     whirl (>= 0.1.8.9000)
 VignetteBuilder: 
-    knitr, 
-    rmarkdown
+    knitr, rmarkdown
+Remotes: 
+    github::NovoNordisk-OpenSource/connector,
+    github::NovoNordisk-Opensource/whirl
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: connector.databricks
 Title: Expansion of the connector package for enabling connections to
     databricks
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: c(
     person("Steffen Falgreen", "Larsen", , "sffl@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# connector.databricks 0.0.4
+
+* Minor tweaks to DESCRIPTION. Removed references to 'external' non-CRAN GitHub packages.
+
 # connector.databricks 0.0.3
 
 ## Breaking Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # connector.databricks 0.0.4
 
-* Minor tweaks to DESCRIPTION. Removed references to 'external' non-CRAN GitHub packages.
+* Minor tweaks to the DESCRIPTION file. Removed references to 'external' non-CRAN GitHub packages.
 
 # connector.databricks 0.0.3
 


### PR DESCRIPTION
Remove pointers to GitHub resources. Fixes #51.  Also needed for CRAN releases in the future. 

https://remotes.r-lib.org/articles/dependencies.html#cran-submission