### PR TITLE
Update brickster version to (>= 0.2.7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: connector.databricks
-Version: 0.0.5
+Version: 0.0.5.9000
 Title: Expansion of the connector package for enabling connections to
     databricks
 Authors@R: c(
@@ -16,7 +16,7 @@ License: Apache License (>= 2)
 URL: https://novonordisk-opensource.github.io/connector.databricks,
     https://github.com/novonordisk-opensource/connector.databricks
 Imports:
-    brickster,
+    brickster (>= 0.2.7),
     checkmate,
     cli,
     connector (>= 0.0.8),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# connector.databricks dev
+
+* Set dependency `brickster (>= 0.2.7)`
+
 # connector.databricks 0.0.5
 
 ## New features and improvements


### PR DESCRIPTION
Bump up, for dependency issue users might have.