### PR TITLE
Fix reading empty tables.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Updated `volume_methods` to use zephyr::msg_info(), replacing cli::cli_alert()
 * Updated `volume_methods`, `table_utils` and `table_methods` to use zephyr::get_option() replacing a bool
 * Updated tests to use zephyr-option, with verbosity = quiet
+* Fix bug regarding empty tables [#73](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/73)
 
 # connector.databricks 0.0.5
 

--- a/R/table_utils.R
+++ b/R/table_utils.R
@@ -195,6 +195,11 @@ read_table_timepoint <- function(
     format = "ARROW_STREAM"
   )
 
+  if (query_result$manifest$total_chunk_count == 0) {
+    return(DBI::dbGetQuery(connector_object$conn, sql_statement))
+    zephyr::msg_success("Table read successfully!")
+  }
+
   statement_id <- query_result$statement_id
   chunk_count <- query_result$manifest$total_chunk_count - 1
 

--- a/R/table_utils.R
+++ b/R/table_utils.R
@@ -196,8 +196,8 @@ read_table_timepoint <- function(
   )
 
   if (query_result$manifest$total_chunk_count == 0) {
-    return(DBI::dbGetQuery(connector_object$conn, sql_statement))
     zephyr::msg_success("Table read successfully!")
+    return(DBI::dbGetQuery(connector_object$conn, sql_statement))
   }
 
   statement_id <- query_result$statement_id

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -152,7 +152,6 @@ test_that("read_table_timepoint fails when needed", {
     )
 })
 
-
 test_that("read_table_timepoint works", {
   table_name <- temp_table_name()
 
@@ -215,4 +214,29 @@ test_that("read_table_timepoint works", {
   )
 
   expect_equal(data2, read_data)
+})
+
+test_that("read and write empty table works", {
+  empty_table <- data.frame(
+    Date = as.Date(character()),
+    File = character(),
+    User = character(),
+    stringsAsFactors = FALSE
+  )
+
+  expect_no_failure(write_table_volume(
+    connector_object = setup_table_connector,
+    empty_table,
+    "empty_table",
+    overwrite = TRUE
+  ))
+
+  expect_no_failure(
+    empty_result <- read_table_timepoint(
+      connector_object = setup_table_connector,
+      name = "empty_table"
+    )
+  )
+
+  expect_equal(empty_table, empty_result)
 })


### PR DESCRIPTION
## Summary
Update `read_table_timepoint` function to return an empty dataframe if there are no records in the table.

## Changes Made
- Using `DBI::dbGetQuery()` function because currently it's not possible to do this in a nice way using brickster.

## Related Issues
- Fixes #73 

## Testing
- Unit test for use case when an empty data frame is written/read

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
