### PR TITLE
Fix tmp volume bug and add test for it.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Updated `volume_methods`, `table_utils` and `table_methods` to use zephyr::get_option() replacing a bool
 * Updated tests to use zephyr-option, with verbosity = quiet
 * Fix bug regarding empty tables [#73](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/73)
+* Fix tmp volume bug [#63](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/63)
 
 # connector.databricks 0.0.5
 

--- a/R/table_utils.R
+++ b/R/table_utils.R
@@ -51,6 +51,14 @@ write_table_volume <- function(
     }
   )
 
+  withr::defer({
+    brickster::db_uc_volumes_delete(
+      catalog = temporary_volume$catalog,
+      schema = temporary_volume$schema,
+      volume = volume_name
+    )
+  })
+
   zephyr::msg_info(
     "Writing to a table
     {connector_object$catalog}/{connector_object$schema}/{name}..."
@@ -76,14 +84,6 @@ write_table_volume <- function(
     )
   }
   zephyr::msg_success("Table written successfully!")
-
-  withr::defer({
-    brickster::db_uc_volumes_delete(
-      catalog = temporary_volume$catalog,
-      schema = temporary_volume$schema,
-      volume = volume_name
-    )
-  })
 }
 
 #' List Databricks tables in a catalog based on tag values

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -240,3 +240,28 @@ test_that("read and write empty table works", {
 
   expect_equal(empty_table, empty_result)
 })
+
+test_that("tmp volume removal works", {
+  # Bad data input to break the test
+  x = list("1", "2", "3")
+
+  expect_error(write_table_volume(
+    connector_object = setup_table_connector,
+    x,
+    "empty_table",
+    overwrite = TRUE
+  ))
+
+  list_of_volumes <- brickster::db_uc_volumes_list(
+    catalog = setup_db_catalog,
+    schema = setup_db_schema
+  )
+
+  expect_no_error(
+    for (volume in list_of_volumes) {
+      if (startsWith(volume[["name"]], "tmp_")) {
+        stop("tmp volume exists")
+      }
+    }
+  )
+})

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -243,7 +243,7 @@ test_that("read and write empty table works", {
 
 test_that("tmp volume removal works", {
   # Bad data input to break the test
-  x = list("1", "2", "3")
+  x <- list("1", "2", "3")
 
   expect_error(write_table_volume(
     connector_object = setup_table_connector,


### PR DESCRIPTION
## Summary
Fix bug with not removing temporary volumes during writing of the table.

## Changes Made
- Update `write_table_volume()` function

## Related Issues
- Fixes #63 

## Testing
- Unit test written to check removal of `tmp` volumes

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
