### PR TITLE
feat/msg_on_connect: Add connection status message during cluster initialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("Vladimir", "Obucina", , "vlob@novonordisk.com", role = "aut"),
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = "aut"),
     person("Oliver", "Lundsgaard", , "ovlr@novonordisk.com", role = "ctb"),
+    person("Skander", "Mulder", , "sktf@novonordisk.com", role = "ctb"),
     person("Novo Nordisk A/S", role = "cph")
   )
 Description: Expands the connector package to handle databricks. This

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # connector.databricks dev
 
+* Added `Connecting to cluster, please wait..` as a zephyr::msg_info prior to initialization of table and volume connection
 * Set dependency `brickster (>= 0.2.7)`
 * Add github templates for issues, features and PRs
 * Updated `volume_methods` to use zephyr::msg_info(), replacing cli::cli_alert()

--- a/R/table.R
+++ b/R/table.R
@@ -141,9 +141,10 @@ ConnectorDatabricksTable <- R6::R6Class(
         any.missing = FALSE,
         null.ok = TRUE
       )
-
       private$.catalog <- catalog
       private$.schema <- schema
+
+      zephyr::msg_info("Connecting to cluster, please wait..")
 
       super$initialize(
         drv = odbc::databricks(),

--- a/R/volume.R
+++ b/R/volume.R
@@ -152,6 +152,8 @@ ConnectorDatabricksVolume <- R6::R6Class(
       volume <- split_path[5]
       path <- paste(split_path[5:length(split_path)], collapse = "/")
 
+      zephyr::msg_info("Connecting to cluster, please wait..")
+
       # Check if volume exists and create it if it does not
       private$.check_databricks_volume_exists(
         catalog = catalog,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -92,6 +92,8 @@ roxygenize
 RoxygenNote
 Rproj
 sffl
+Skander
+sktf
 sparklyr
 sqlpath
 src


### PR DESCRIPTION
## Summary
Added a user-friendly status message that displays during cluster connection initialization. This provides better user feedback during the connection process and improves the overall user experience by indicating that the system is working on establishing the connection.

## Changes Made
- Added `Connecting to cluster, please wait..` as a `zephyr::msg_info` message prior to initialization of table and volume connections

## Related Issues
- Improves user experience during connection initialization

## Testing
- Manually verified that the message appears correctly during connection process
- Ensured the message doesn't interfere with normal operation flow

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge

