### PR TITLE
Fix upload_directory_cnt for Volumes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # connector.databricks dev
 
+* Fix naming convention in `upload_directory_cnt.DatabricksVolume` [#84](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/84)
 * Added `Connecting to cluster, please wait..` as a zephyr::msg_info prior to initialization of table and volume connection
 * Set dependency `brickster (>= 0.2.7)`
 * Add github templates for issues, features and PRs
@@ -10,7 +11,7 @@
 * Fix tmp volume bug [#63](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/63)
 * Add `upload_directory_cnt()` and `download_directory_cnt()` methods for
 `ConnectorDatabricksVolume` class. Solves [#77](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/77)
-* Update `remove_directory_cnt()` method for `ConnectorDatabricksVolume` class, now iterates over directories and erases all the subdirectories and files. Solve [#78](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/78)
+* Update `remove_directory_cnt()` method for `ConnectorDatabricksVolume` class, now iterates over directories and erases all the subdirectories and files. Solves [#78](https://github.com/NovoNordisk-OpenSource/connector.databricks/issues/78)
 * Update `connector` dependency to `0.1.0` official CRAN version.
 
 # connector.databricks 0.0.5

--- a/R/volume_methods.R
+++ b/R/volume_methods.R
@@ -226,7 +226,11 @@ upload_directory_cnt.ConnectorDatabricksVolume <- function(
       extra_class,
       which(extra_class == "ConnectorDatabricksVolume") - 1
     )
-    connector_object <- connector_databricks_volume(paste0(dir, "/", name))
+    connector_object <- connector_databricks_volume(paste0(
+      connector_object$full_path,
+      "/",
+      name
+    ))
   }
 
   return(

--- a/R/volume_methods.R
+++ b/R/volume_methods.R
@@ -206,17 +206,15 @@ tbl_cnt.ConnectorDatabricksVolume <- function(connector_object, name, ...) {
 upload_directory_cnt.ConnectorDatabricksVolume <- function(
   connector_object,
   dir,
-  name,
+  name = basename(dir),
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...
 ) {
-  dir_path <- file.path(connector_object$full_path, dir)
-
   upload_directory(
     dir = dir,
     name = name,
-    dir_path = dir_path,
+    dir_path = connector_object$full_path,
     overwrite = overwrite,
     ...
   )
@@ -228,7 +226,7 @@ upload_directory_cnt.ConnectorDatabricksVolume <- function(
       extra_class,
       which(extra_class == "ConnectorDatabricksVolume") - 1
     )
-    connector_object <- connector_databricks_volume(dir_path)
+    connector_object <- connector_databricks_volume(paste0(dir, "/", name))
   }
 
   return(

--- a/R/volume_utils.R
+++ b/R/volume_utils.R
@@ -87,17 +87,16 @@ remove_directory <- function(dir_path) {
 #' @noRd
 upload_directory <- function(
   dir,
-  name = NULL,
+  name,
   dir_path,
   overwrite = TRUE,
   ...
 ) {
   checkmate::assert_directory_exists(dir)
-  checkmate::assert_string(name, null.ok = TRUE)
   checkmate::assert_string(dir_path)
   checkmate::assert_logical(overwrite, null.ok = FALSE)
 
-  if (is.null(name)) {
+  if (missing(name)) {
     name <- basename(dir)
   }
 

--- a/man/upload_directory_cnt.Rd
+++ b/man/upload_directory_cnt.Rd
@@ -17,7 +17,7 @@ upload_directory_cnt(
 \method{upload_directory_cnt}{ConnectorDatabricksVolume}(
   connector_object,
   dir,
-  name,
+  name = basename(dir),
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...

--- a/tests/testthat/test-volume.R
+++ b/tests/testthat/test-volume.R
@@ -290,10 +290,23 @@ test_that("ConnectorDatabricksVolume upload/download works", {
     dir = "nested_structure_volumes",
     overwrite = TRUE
   ))
+
+  expect_no_failure(setup_volume_connector$remove_directory_cnt(
+    name = "nested_structure_volumes"
+  ))
+
+  expect_no_failure(
+    setup_volume_connector |>
+      upload_directory_cnt(
+        dir = "nested_structure_volumes"
+      )
+  )
+
   withr::defer({
-    setup_volume_connector$remove_directory_cnt(
-      name = "nested_structure_volumes"
-    )
+    setup_volume_connector |>
+      remove_directory_cnt(
+        name = "nested_structure_volumes"
+      )
     expect_error(brickster::db_volume_dir_exists(paste0(
       "/Volumes/",
       setup_db_volume_path,
@@ -305,7 +318,17 @@ test_that("ConnectorDatabricksVolume upload/download works", {
     name = "nested_structure_volumes",
     dir = "nested_structure_volumes_downloaded"
   ))
+
+  expect_no_failure(
+    setup_volume_connector |>
+      download_directory_cnt(
+        name = "nested_structure_volumes",
+        dir = "nested_structure_volumes_downloaded_pipe"
+      )
+  )
+
   withr::defer({
     fs::dir_delete("nested_structure_volumes_downloaded")
+    fs::dir_delete("nested_structure_volumes_downloaded_pipe")
   })
 })


### PR DESCRIPTION
## Summary
Updated `upload_directory_cnt.DatabricksVolume` method, replaced logic for concatenating directory path in Databricks.

## Changes Made
- Update `name` parameter to take `basename(dir)` by default
- Update `upload_directory` function logic for how to handle when `name` parameter is not provided.

## Related Issues
- Fixes #84

## Testing
- Update unit test in `test-volume.R`

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
